### PR TITLE
feat: adjust tournament badge name to have gold, silver, or bronze ba…

### DIFF
--- a/src/components/PageComponents/BadgePage/Form/AddTournamentBadgeForm.tsx
+++ b/src/components/PageComponents/BadgePage/Form/AddTournamentBadgeForm.tsx
@@ -33,7 +33,7 @@ export const AddTournamentBadgeForm = ({ onClose, defaultData, onSubmit }: Props
       image_url1: defaultData?.firstPlace.image_url || '',
       image_url2: defaultData?.secondPlace.image_url || '',
       image_url3: defaultData?.thirdPlace.image_url || '',
-      name: defaultData?.firstPlace.name || '',
+      name: defaultData?.firstPlace.name.replace(/Gold /, '') || '',
       vp_point1: defaultData?.firstPlace.vp_point || 0,
       vp_point2: defaultData?.secondPlace.vp_point || 0,
       vp_point3: defaultData?.thirdPlace.vp_point || 0,
@@ -50,7 +50,7 @@ export const AddTournamentBadgeForm = ({ onClose, defaultData, onSubmit }: Props
         {
           ...defaultData?.firstPlace,
           badge_category: data.badge_category,
-          name: data.name,
+          name: `Gold ${data.name}`,
           image_url: data.image_url1,
           status: data.status,
           vp_point: data.vp_point1,
@@ -67,7 +67,7 @@ export const AddTournamentBadgeForm = ({ onClose, defaultData, onSubmit }: Props
         {
           ...defaultData?.secondPlace,
           badge_category: data.badge_category,
-          name: data.name,
+          name: `Silver ${data.name}`,
           image_url: data.image_url2,
           status: data.status,
           vp_point: data.vp_point2,
@@ -84,7 +84,7 @@ export const AddTournamentBadgeForm = ({ onClose, defaultData, onSubmit }: Props
         {
           ...defaultData?.thirdPlace,
           badge_category: data.badge_category,
-          name: data.name,
+          name: `Bronze ${data.name}`,
           image_url: data.image_url3,
           status: data.status,
           vp_point: data.vp_point3,

--- a/src/components/PageComponents/BadgePage/Modal/EditTournamentBadgeModal.tsx
+++ b/src/components/PageComponents/BadgePage/Modal/EditTournamentBadgeModal.tsx
@@ -32,7 +32,7 @@ const EditTournamentBadgeModal = ({ open, onOpenChange, badgeCode = '' }: Props)
       <ModalContent hideCloseIcon className='max-w-3xl max-h-[90%] overflow-hidden flex flex-col'>
         <ModalHeader className='h-fit'>
           <ModalTitle>
-            Add New Tournament Badge
+            Edit Tournament Badge
           </ModalTitle>
         </ModalHeader>
         <Separator />

--- a/src/components/PageComponents/TournamentPage/AddTournament/prize-form.tsx
+++ b/src/components/PageComponents/TournamentPage/AddTournament/prize-form.tsx
@@ -41,7 +41,7 @@ const PrizeForm: React.FC<{ tournamentBadges?: TournamentDetailType['tournament_
 
         return {
           value: badgeGroupKey,
-          label: generalBadgeData.name,
+          label: generalBadgeData.name.replace(/(Gold|Silver|Bronze) /, ''),
           data: badgeGroupData
         }
       }) as unknown


### PR DESCRIPTION
Hi Team,

I've added the logic to add the tournament badge name based on the winner position. Here's the mapping value for each:

- 1st winner: 'Gold {badge_name}'
- 2nd winner: 'Silver {badge_name}'
- 3rd winner: 'Bronze {badge_name}'
 
Please kindly check. Thank you!