### PR TITLE
fix: next-js image configuration url remove whitelist

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@
 /** @type {import('next').NextConfig} */
 
 const nextConfig = {
- 
+
   eslint: {
     dirs: ['src'],
   },
@@ -42,8 +42,8 @@ const nextConfig = {
 
     return config;
   },
-  images:{
-    remotePatterns:[
+  images: {
+    remotePatterns: [
       {
         protocol: 'https',
         hostname: 'i.pravatar.cc',
@@ -62,7 +62,7 @@ const nextConfig = {
       },
       {
         protocol: 'https',
-        hostname: 'dots-production.s3.ap-southeast-1.amazonaws.com/dots/uploads'
+        hostname: 'dots-production.s3.ap-southeast-1.amazonaws.com'
       }
     ]
   }


### PR DESCRIPTION
Hi Team,

This release is to fix next js images configuration. Previously the image is not shown on some assets due to the source url is not whitelisted on the next js configuration.

Thank you!